### PR TITLE
Update Lyra Finance URL redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ yarn install
 
 ### Resources
 
-- [Lyra Finance Core NPM Package](https://www.npmjs.com/package/@lyrafinance/core)
+- [Lyra Finance Core NPM Package](https://www.npmjs.com/package/@lyrafinance/protocol)
 - [Lyra Finance Repositories](https://github.com/lyra-finance)
 
 ## Contributing


### PR DESCRIPTION
`/core` was deprecated in favour of `/protocol`